### PR TITLE
Use `::core` to refer to the core crate

### DIFF
--- a/src/nonzero.rs
+++ b/src/nonzero.rs
@@ -23,7 +23,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroUsize::new_unchecked(#lit)
+                    ::core::num::NonZeroUsize::new_unchecked(#lit)
                 }
             }
         }
@@ -32,7 +32,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroU8::new_unchecked(#lit)
+                    ::core::num::NonZeroU8::new_unchecked(#lit)
                 }
             }
         }
@@ -41,7 +41,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroU16::new_unchecked(#lit)
+                    ::core::num::NonZeroU16::new_unchecked(#lit)
                 }
             }
         }
@@ -50,7 +50,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroU32::new_unchecked(#lit)
+                    ::core::num::NonZeroU32::new_unchecked(#lit)
                 }
             }
         }
@@ -59,7 +59,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroU64::new_unchecked(#lit)
+                    ::core::num::NonZeroU64::new_unchecked(#lit)
                 }
             }
         }
@@ -71,7 +71,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroIsize::new_unchecked(#neg #lit)
+                    ::core::num::NonZeroIsize::new_unchecked(#neg #lit)
                 }
             }
         }
@@ -80,7 +80,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroI8::new_unchecked(#neg #lit)
+                    ::core::num::NonZeroI8::new_unchecked(#neg #lit)
                 }
             }
         }
@@ -89,7 +89,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroI16::new_unchecked(#neg #lit)
+                    ::core::num::NonZeroI16::new_unchecked(#neg #lit)
                 }
             }
         }
@@ -98,7 +98,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroI32::new_unchecked(#neg #lit)
+                    ::core::num::NonZeroI32::new_unchecked(#neg #lit)
                 }
             }
         }
@@ -107,7 +107,7 @@ pub(crate) fn nonzero(integer: SignedInteger) -> Result<TokenStream> {
             check_zero(&lit, val)?;
             quote! {
                 unsafe {
-                    core::num::NonZeroI64::new_unchecked(#neg #lit)
+                    ::core::num::NonZeroI64::new_unchecked(#neg #lit)
                 }
             }
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,6 +6,9 @@ use nonzero::nonzero as nz;
 
 #[test]
 fn test() {
+    // Make sure we don't shadow it accidentally.
+    mod core {}
+
     // unsigned integers
     assert_eq!(nz!(1usize), NonZeroUsize::new(1).unwrap());
     assert_eq!(nz!(1u8), NonZeroU8::new(1).unwrap());


### PR DESCRIPTION
Otherwise, a `core` module in scope would shadow it and expanded code will most likely not compile and definitely won't do the right thing.

Fixes: #4